### PR TITLE
Currently the `docker-compose up` fails.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,14 @@ Variable | Default | Description
 ## Run the application using `docker-compose`
 
 ```
-# Example docker-compose.yml
 version: '3'
 services:
   db:
     image: mysql
     volumes:
       - db_data:/var/lib/mysql
+      # This is needed to allow old PHP versions to work with newer MySQL
+      - ./mysql-config:/etc/mysql/conf.d
     environment:
       MYSQL_ROOT_PASSWORD: password
       MYSQL_DATABASE: moodle
@@ -97,7 +98,7 @@ services:
     environment:
       PMA_HOST: database
   tasks:
-    image: funkyfuture/deck-chores
+    image: funkyfuture/deck-chores:1
     restart: unless-stopped
     environment:
       TIMEZONE: Europe/Paris

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
     image: mysql
     volumes:
       - db_data:/var/lib/mysql
+      # This is needed to allow old PHP versions to work with newer MySQL
+      - ./mysql-config:/etc/mysql/conf.d
     environment:
       MYSQL_ROOT_PASSWORD: password
       MYSQL_DATABASE: moodle

--- a/mysql-config/config-file.cnf
+++ b/mysql-config/config-file.cnf
@@ -1,0 +1,6 @@
+[mysqld]
+
+# Switch back to MySQL 5 authentication
+default_authentication_plugin=mysql_native_password
+
+


### PR DESCRIPTION
This allows the old MySQL authentication to work without this fix you get:

The server requested authentication method unknown to the client [caching_sha2_password] in Standard input code on line 15

Errors appear from moodle when it attempts to connect to the DB. This also updates the example docker-compose in the README.md as it was out of sync.